### PR TITLE
Add MCP retrieval component

### DIFF
--- a/agent/component/__init__.py
+++ b/agent/component/__init__.py
@@ -50,6 +50,7 @@ from .template import Template, TemplateParam
 from .email import Email, EmailParam
 from .iteration import Iteration, IterationParam
 from .iterationitem import IterationItem, IterationItemParam
+from .mcp_retrieval import MCPRetrieval, MCPRetrievalParam
 
 
 def component_class(class_name):
@@ -65,6 +66,8 @@ __all__ = [
     "GenerateParam",
     "Retrieval",
     "RetrievalParam",
+    "MCPRetrieval",
+    "MCPRetrievalParam",
     "Answer",
     "AnswerParam",
     "Categorize",

--- a/agent/component/mcp_retrieval.py
+++ b/agent/component/mcp_retrieval.py
@@ -1,0 +1,106 @@
+# Copyright 2025 The InfiniFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MCP retrieval component.
+
+This component uses a running MCP server to fetch chunks from
+remote datasets via the ``ragflow_retrieval`` tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from abc import ABC
+from typing import Any, Dict, List
+
+import pandas as pd
+
+try:
+    from mcp.client.session import ClientSession
+    from mcp.client.sse import sse_client
+except Exception:  # pragma: no cover - MCP client may not be installed
+    ClientSession = None  # type: ignore
+    sse_client = None  # type: ignore
+
+from agent.component.base import ComponentBase, ComponentParamBase
+
+
+class MCPRetrievalParam(ComponentParamBase):
+    """Parameters for :class:`MCPRetrieval`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.mcp_url: str = "http://localhost:9382/sse"
+        self.dataset_ids: List[str] = []
+        self.document_ids: List[str] = []
+
+    def check(self) -> None:  # pragma: no cover - simple check
+        if not isinstance(self.mcp_url, str):
+            raise ValueError("mcp_url should be a string")
+
+
+class MCPRetrieval(ComponentBase, ABC):
+    """Call ``ragflow_retrieval`` on an MCP server."""
+
+    component_name = "MCPRetrieval"
+
+    async def _async_call_tool(self, question: str) -> Any:
+        if ClientSession is None or sse_client is None:
+            raise RuntimeError("MCP client library is not available")
+
+        async with sse_client(self._param.mcp_url) as streams:
+            async with ClientSession(streams[0], streams[1]) as session:
+                await session.initialize()
+                response = await session.call_tool(
+                    name="ragflow_retrieval",
+                    arguments={
+                        "dataset_ids": self._param.dataset_ids,
+                        "document_ids": self._param.document_ids,
+                        "question": question,
+                    },
+                )
+                return response
+
+    def _run(self, history, **kwargs):  # noqa: D401 - interface defined in base
+        ans = self.get_input()
+        question = str(ans["content"][0]) if "content" in ans else ""
+        if not question:
+            return MCPRetrieval.be_output("")
+
+        try:
+            res = asyncio.run(self._async_call_tool(question))
+        except Exception as e:  # pragma: no cover - network failures
+            return MCPRetrieval.be_output(f"Error: {e}")
+
+        try:
+            outputs = res.outputs  # type: ignore[attr-defined]
+        except AttributeError:
+            try:
+                res_dict: Dict[str, Any] = res.model_dump()  # type: ignore[attr-defined]
+                outputs = res_dict.get("outputs", [])
+            except Exception:
+                outputs = []
+
+        contents = []
+        for item in outputs:
+            text = getattr(item, "text", None)
+            if text is None and isinstance(item, dict):
+                text = item.get("text")
+            if text is None:
+                text = str(item)
+            contents.append(text)
+
+        if not contents:
+            return MCPRetrieval.be_output("")
+        return pd.DataFrame({"content": contents})

--- a/web/src/pages/agent/constant.tsx
+++ b/web/src/pages/agent/constant.tsx
@@ -69,6 +69,7 @@ export const BeginId = 'begin';
 export enum Operator {
   Begin = 'Begin',
   Retrieval = 'Retrieval',
+  MCPRetrieval = 'MCPRetrieval',
   Generate = 'Generate',
   Answer = 'Answer',
   Categorize = 'Categorize',
@@ -126,6 +127,7 @@ export const AgentOperatorList = [
 
 export const operatorIconMap = {
   [Operator.Retrieval]: RocketOutlined,
+  [Operator.MCPRetrieval]: RocketOutlined,
   [Operator.Generate]: MergeCellsOutlined,
   [Operator.Answer]: SendOutlined,
   [Operator.Begin]: BeginIcon,
@@ -177,6 +179,10 @@ export const operatorMap: Record<
   }
 > = {
   [Operator.Retrieval]: {
+    backgroundColor: '#cad6e0',
+    color: '#385974',
+  },
+  [Operator.MCPRetrieval]: {
     backgroundColor: '#cad6e0',
     color: '#385974',
   },
@@ -304,6 +310,9 @@ export const operatorMap: Record<
 export const componentMenuList = [
   {
     name: Operator.Retrieval,
+  },
+  {
+    name: Operator.MCPRetrieval,
   },
   {
     name: Operator.Generate,
@@ -677,6 +686,7 @@ export const RestrictedUpstreamMap = {
     Operator.Relevant,
   ],
   [Operator.Retrieval]: [Operator.Begin, Operator.Retrieval],
+  [Operator.MCPRetrieval]: [Operator.Begin, Operator.MCPRetrieval],
   [Operator.Generate]: [Operator.Begin, Operator.Relevant],
   [Operator.Message]: [
     Operator.Begin,
@@ -732,6 +742,7 @@ export const NodeMap = {
   [Operator.Begin]: 'beginNode',
   [Operator.Categorize]: 'categorizeNode',
   [Operator.Retrieval]: 'retrievalNode',
+  [Operator.MCPRetrieval]: 'retrievalNode',
   [Operator.Generate]: 'generateNode',
   [Operator.Answer]: 'logicNode',
   [Operator.Message]: 'messageNode',

--- a/web/src/pages/agent/form-sheet/use-form-config-map.tsx
+++ b/web/src/pages/agent/form-sheet/use-form-config-map.tsx
@@ -80,6 +80,29 @@ export function useFormConfigMap() {
         ),
       }),
     },
+    [Operator.MCPRetrieval]: {
+      component: RetrievalForm,
+      defaultValues: { query: [] },
+      schema: z.object({
+        name: z
+          .string()
+          .min(1, {
+            message: t('common.namePlaceholder'),
+          })
+          .trim(),
+        age: z
+          .string()
+          .min(1, {
+            message: t('common.namePlaceholder'),
+          })
+          .trim(),
+        query: z.array(
+          z.object({
+            type: z.string(),
+          }),
+        ),
+      }),
+    },
     [Operator.Generate]: {
       component: GenerateForm,
       defaultValues: {

--- a/web/src/pages/agent/hooks.tsx
+++ b/web/src/pages/agent/hooks.tsx
@@ -101,6 +101,7 @@ export const useInitializeOperatorParams = () => {
     return {
       [Operator.Begin]: initialBeginValues,
       [Operator.Retrieval]: initialRetrievalValues,
+      [Operator.MCPRetrieval]: initialRetrievalValues,
       [Operator.Generate]: { ...initialGenerateValues, llm_id: llmId },
       [Operator.Answer]: {},
       [Operator.Categorize]: { ...initialCategorizeValues, llm_id: llmId },

--- a/web/src/pages/flow/constant.tsx
+++ b/web/src/pages/flow/constant.tsx
@@ -70,6 +70,7 @@ export const BeginId = 'begin';
 export enum Operator {
   Begin = 'Begin',
   Retrieval = 'Retrieval',
+  MCPRetrieval = 'MCPRetrieval',
   Generate = 'Generate',
   Answer = 'Answer',
   Categorize = 'Categorize',
@@ -112,6 +113,7 @@ export const CommonOperatorList = Object.values(Operator).filter(
 
 export const operatorIconMap = {
   [Operator.Retrieval]: RocketOutlined,
+  [Operator.MCPRetrieval]: RocketOutlined,
   [Operator.Generate]: MergeCellsOutlined,
   [Operator.Answer]: SendOutlined,
   [Operator.Begin]: BeginIcon,
@@ -163,6 +165,10 @@ export const operatorMap: Record<
   }
 > = {
   [Operator.Retrieval]: {
+    backgroundColor: '#cad6e0',
+    color: '#385974',
+  },
+  [Operator.MCPRetrieval]: {
     backgroundColor: '#cad6e0',
     color: '#385974',
   },
@@ -290,6 +296,9 @@ export const operatorMap: Record<
 export const componentMenuList = [
   {
     name: Operator.Retrieval,
+  },
+  {
+    name: Operator.MCPRetrieval,
   },
   {
     name: Operator.Generate,
@@ -665,6 +674,7 @@ export const RestrictedUpstreamMap = {
     Operator.Relevant,
   ],
   [Operator.Retrieval]: [Operator.Begin, Operator.Retrieval],
+  [Operator.MCPRetrieval]: [Operator.Begin, Operator.MCPRetrieval],
   [Operator.Generate]: [Operator.Begin, Operator.Relevant],
   [Operator.Message]: [
     Operator.Begin,
@@ -720,6 +730,7 @@ export const NodeMap = {
   [Operator.Begin]: 'beginNode',
   [Operator.Categorize]: 'categorizeNode',
   [Operator.Retrieval]: 'retrievalNode',
+  [Operator.MCPRetrieval]: 'retrievalNode',
   [Operator.Generate]: 'generateNode',
   [Operator.Answer]: 'logicNode',
   [Operator.Message]: 'messageNode',

--- a/web/src/pages/flow/flow-drawer/index.tsx
+++ b/web/src/pages/flow/flow-drawer/index.tsx
@@ -63,6 +63,7 @@ interface IProps {
 const FormMap = {
   [Operator.Begin]: BeginForm,
   [Operator.Retrieval]: RetrievalForm,
+  [Operator.MCPRetrieval]: RetrievalForm,
   [Operator.Generate]: GenerateForm,
   [Operator.Answer]: AnswerForm,
   [Operator.Categorize]: CategorizeForm,

--- a/web/src/pages/flow/hooks.tsx
+++ b/web/src/pages/flow/hooks.tsx
@@ -99,6 +99,7 @@ export const useInitializeOperatorParams = () => {
     return {
       [Operator.Begin]: initialBeginValues,
       [Operator.Retrieval]: initialRetrievalValues,
+      [Operator.MCPRetrieval]: initialRetrievalValues,
       [Operator.Generate]: { ...initialGenerateValues, llm_id: llmId },
       [Operator.Answer]: {},
       [Operator.Categorize]: { ...initialCategorizeValues, llm_id: llmId },


### PR DESCRIPTION
## Summary
- support MCP retrieval via new component `MCPRetrieval`
- register MCP retrieval component
- expose MCP retrieval in frontend constants and hooks
- map MCP retrieval forms to RetrievalForm

## Testing
- `ruff check agent/component/mcp_retrieval.py agent/component/__init__.py`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683aff36f9108326886bb4ecf9d47ff2